### PR TITLE
Fix invalid iframe attributes on githubbtn

### DIFF
--- a/www/themes/default/layouts/index.html
+++ b/www/themes/default/layouts/index.html
@@ -30,7 +30,8 @@
   </div>
   <div class="row text-center">
     <div class="col-sm-6 text-right">
-      <iframe src="https://ghbtns.com/github-btn.html?user=arschles&repo=go-in-5-minutes&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=arschles&repo=go-in-5-minutes&type=star&count=true&size=large" 
+	      style="border:0; width:160px; height:30px; overflow:hidden"></iframe>
     </div>
     <div class="col-sm-6 text-left">
       <div class="g-ytsubscribe" data-channelid="UC2GHqYE3fVJMncbrRd8AqcA" data-layout="full" data-count="default"></div>


### PR DESCRIPTION
Replace deprecated iframe attributes frameborder and scrolling, and invalid height and width values with equivalent css on `index.html` Github button.

- frameborder and scrolling replaced with equivalent style`border:0` (border-width:0) and `overflow:hidden`
- invalid values on width and height (required numeric values), also replaced with equivalent styles on same iframe
- Newline added before style attribute to avoid lengthy column width
