### PR TITLE
Fix template in episode5 (#121)

### DIFF
--- a/episode5/templates/layout.html
+++ b/episode5/templates/layout.html
@@ -3,7 +3,7 @@
 <head>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css" integrity="sha384-aUGj/X2zp5rLCbBxumKTCw2Z50WgIr1vs/PFN4praOTvYXWlVyh2UtNUU0KAUhAX" crossorigin="anonymous">
-  {{block "css"}}
+  {{block "css" ""}}{{end}}
 </head>
 <body class="container">
   {{yield}}
@@ -13,7 +13,7 @@
   <script type="text/javascript" src="https://fb.me/react-with-addons-0.14.1.js"></script>
   <script type="text/javascript" src="https://fb.me/react-dom-0.14.1.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
-  {{block "js"}}
-  {{block "jsx"}}
+  {{block "js" ""}}{{end}}
+  {{block "jsx-candies" ""}}{{end}}
 </body>
 </html>


### PR DESCRIPTION
It seems that the block template syntax changed
during go versions.

This works with the current go version 1.8.1.