### PR TITLE
fix package import in episode5

### DIFF
--- a/episode5/handlers/api/create_candy.go
+++ b/episode5/handlers/api/create_candy.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/arschles/go-in-5-minutes/episode5/models"
 )

--- a/episode5/models/mongo_db.go
+++ b/episode5/models/mongo_db.go
@@ -1,8 +1,8 @@
 package models
 
 import (
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
 )
 
 const (


### PR DESCRIPTION
Replace package import in episode5
```
import (
    "labix.org/v2/mgo"
    "labix.org/v2/mgo/bson"
)
```
with
```
import{
    "gopkg.in/mgo.v2"
    "gopkg.in/mgo.v2/bson"
}
```