### PR TITLE
removing ads

### DIFF
--- a/www/content/screencast/episode_14_using_templates.md
+++ b/www/content/screencast/episode_14_using_templates.md
@@ -23,4 +23,4 @@ Go In 5 Minutes screencasts will always be free, while extended screencasts will
 
 See [https://gum.co/gifm-x-14](https://gum.co/gifm-x-14) for more details.
 
-{{< screencast_bottom youtube_id="Fr5cdsOZfGw" show_ad=false github_episode="epsode14">}}
+{{< screencast_bottom youtube_id="Fr5cdsOZfGw" github_episode="epsode14">}}

--- a/www/layouts/shortcodes/screencast_bottom.html
+++ b/www/layouts/shortcodes/screencast_bottom.html
@@ -1,30 +1,5 @@
 {{ $has_ad := .Get "show_ad" }}
 
-{{ if (or (eq $has_ad true) (eq $has_ad "")) }}
-<div
-    class="gumroad_theres_more panel panel-info">
-    <div class="panel-body">
-        <p>This screencast only scratches the surface. 
-        Subscribe to my new screencast series on Go web apps to 
-        dive deeper.</p>
-    </div>
-    <div class="panel-footer">
-        <a
-            role="button"
-            class="btn btn-primary"
-            href="https://gum.co/hgHhj?wanted=true"
-            target="_blank">
-            Learn more
-        </a>
-        <p>
-            <small>
-                *This subscription series is a related product.
-                Go in 5 Minutes screencasts will always be free.
-            </small>
-        </p>
-    </div>
-</div>
-{{ end }}
 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
     <iframe src='https://www.youtube.com/embed/{{ .Get "youtube_id"}}?autoplay=0' style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="YouTube Video"></iframe>
 </div>


### PR DESCRIPTION
This patch removes the "This screencast only scratches the surface. Subscribe to my new screencast series on Go web apps to dive deeper." ads. I'll add those screencasts to which that ad refers later on.
